### PR TITLE
rewrite parser to use syn 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Lukas Lueg <lukas.lueg@gmail.com>"]
 
 [dependencies]
-syn = { version = "0.14", features = ["full", "extra-traits"] }
+syn = { version = "0.15", features = ["full", "extra-traits"] }
 railroad = { git = "https://github.com/lukaslueg/railroad" }
 proc-macro2 = { version = "0.4", default-features=false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub mod lowering;
 pub mod diagram;
 
 /// Create a syntax diagram as an SVG from the given macro_rules!-source.
-pub fn to_diagram(src: &str) -> Result<String, syn::synom::ParseError> {
+pub fn to_diagram(src: &str) -> Result<String, syn::parse::Error> {
 
     // Parser-tree, basically as rustc sees it
     let macro_rules = parser::parse(&src)?;

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -131,6 +131,7 @@ impl From<parser::Matcher> for Matcher {
             parser::Matcher::Punct(p) => Matcher::Literal(p.to_string()),
             parser::Matcher::Ident(i) => Matcher::Literal(i.to_string()),
             parser::Matcher::Literal(l) => Matcher::Literal(l.to_string()),
+            parser::Matcher::Lifetime(l) => Matcher::Literal(l.to_string()),
             parser::Matcher::Group { delimiter, content } => {
                 // We actually keep Groups as the parser sees them, representing them
                 // visually as boxed (literally "boxed", like a rectangle of pixels) sequence.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@
 use syn;
 use proc_macro2::{Delimiter, Ident, Literal, Punct, TokenStream};
 
+use syn::Lifetime;
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
 use syn::token;
@@ -24,6 +25,7 @@ pub enum Matcher {
     Punct(Punct),
     Ident(Ident),
     Literal(Literal),
+    Lifetime(Lifetime),
     Group {
         delimiter: Delimiter,
         content: Vec<Matcher>,
@@ -219,8 +221,8 @@ impl Parse for Matcher {
                 Ok((Matcher::Punct(punct), remaining))
             } else if let Some((ident, remaining)) = cursor.ident() {
                 Ok((Matcher::Ident(ident), remaining))
-            } else if let Some((syn::Lifetime { ident, .. }, remaining)) = cursor.lifetime() {
-                Ok((Matcher::Ident(ident), remaining))
+            } else if let Some((lifetime, remaining)) = cursor.lifetime() {
+                Ok((Matcher::Lifetime(lifetime), remaining))
             } else if let Some((literal, remaining)) = cursor.literal() {
                 Ok((Matcher::Literal(literal), remaining))
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,8 +140,8 @@ impl Parse for Rule {
         Ok(Rule {
             matcher: {
                 let mut v = Vec::new();
-                while let Ok(m) = matcher.parse() {
-                    v.push(m);
+                while !matcher.is_empty() {
+                    v.push(matcher.parse()?);
                 }
                 v
             },
@@ -169,8 +169,8 @@ fn parse_repeat_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
     Ok(Matcher::Repeat {
         content: {
             let mut v = Vec::new();
-            while let Ok(matcher) = content.parse() {
-                v.push(matcher);
+            while !content.is_empty() {
+                v.push(content.parse()?);
             }
             v
         },
@@ -186,8 +186,8 @@ fn parse_group_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
         delimiter,
         content: {
             let mut v = Vec::new();
-            while let Ok(matcher) = content.parse() {
-                v.push(matcher);
+            while !content.is_empty() {
+                v.push(content.parse()?);
             }
             v
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,9 +3,8 @@
 use syn;
 use proc_macro2::{Delimiter, Ident, Literal, Punct, TokenStream};
 
-use syn::punctuated::Punctuated;
-use syn::synom::Synom;
-use syn::token::Dollar;
+use syn::ext::IdentExt;
+use syn::parse::{Parse, ParseStream};
 
 #[derive(Debug)]
 pub struct MacroRules {
@@ -74,109 +73,225 @@ pub enum Fragment {
 }
 
 macro_rules! delimited {
-    ($i:expr, $submac:ident!( $($args:tt)* )) => {
-        alt!($i,
-            parens!($submac!($($args)*)) => { |(_, content)| (Delimiter::Parenthesis, content) } |
-            braces!($submac!($($args)*)) => { |(_, content)| (Delimiter::Brace, content) } |
-            brackets!($submac!($($args)*)) => { |(_, content)| (Delimiter::Bracket, content) }
-        )
+    ($content:ident in $cursor:expr) => {
+        if let syn::export::Ok(parens) = syn::group::parse_parens(&$cursor) {
+            $content = parens.content;
+            Delimiter::Parenthesis
+        } else if let syn::export::Ok(braces) = syn::group::parse_braces(&$cursor) {
+            $content = braces.content;
+            Delimiter::Brace
+        } else if let syn::export::Ok(brackets) = syn::group::parse_brackets(&$cursor) {
+            $content = brackets.content;
+            Delimiter::Bracket
+        } else {
+            return syn::export::Err($cursor.error("expected delimiter"));
+        }
     };
 }
 
-impl Synom for MacroRules {
-    named!(parse -> Self, do_parse!(
-        custom_keyword!(macro_rules) >>
-        punct!(!) >>
-        name: syn!(Ident) >>
-        rules: delimited!(call!(Punctuated::<Rule, Token![;]>::parse_terminated_nonempty)) >>
-        cond!(rules.0 == Delimiter::Parenthesis || rules.0 == Delimiter::Bracket, punct!(;)) >>
-        (MacroRules {
+mod kw {
+    custom_keyword!(macro_rules);
+
+    custom_keyword!(ident);
+    custom_keyword!(path);
+    custom_keyword!(expr);
+    custom_keyword!(ty);
+    custom_keyword!(pat);
+    custom_keyword!(stmt);
+    custom_keyword!(block);
+    custom_keyword!(item);
+    custom_keyword!(meta);
+    custom_keyword!(tt);
+    custom_keyword!(vis);
+    custom_keyword!(literal);
+    custom_keyword!(lifetime);
+}
+
+impl Parse for MacroRules {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        input.parse::<kw::macro_rules>()?;
+        input.parse::<syn::token::Bang>()?;
+        let name = input.parse()?;
+
+        let content;
+        delimited!(content in input);
+        let mut rules = vec![content.parse()?];
+        if content.parse::<syn::token::Semi>().is_ok() {
+            rules.extend(content.parse_terminated::<_, syn::token::Semi>(Rule::parse)?);
+        }
+
+        Ok(MacroRules {
             name,
-            rules: rules.1.into_iter().collect(),
+            rules: rules.into_iter().collect()
         })
-    ));
+    }
 }
 
-impl Synom for Rule {
-    named!(parse -> Self, do_parse!(
-        matcher: delimited!(many0!(syn!(Matcher))) >>
-        punct!(=>) >>
-        expansion: delimited!(syn!(TokenStream)) >>
-        (Rule {
-            matcher: matcher.1,
-            expansion: expansion.1,
+impl Parse for Rule {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        let matcher;
+        delimited!(matcher in input);
+
+        input.parse::<syn::token::FatArrow>()?;
+
+        let expansion;
+        delimited!(expansion in input);
+
+        Ok(Rule {
+            matcher: {
+                let mut v = Vec::new();
+                while let Ok(m) = matcher.parse() {
+                    v.push(m);
+                }
+                v
+            },
+            expansion: expansion.parse()?
         })
-    ));
+    }
 }
 
-impl Synom for Matcher {
-    named!(parse -> Self, alt!(
-        do_parse!(
-            syn!(Dollar) >>
-            name: call!(Ident::parse_any) >>
-            punct!(:) >>
-            fragment: syn!(Fragment) >>
-            (Matcher::Fragment { name, fragment })
-        ) |
-        do_parse!(
-            syn!(Dollar) >>
-            content: parens!(many0!(syn!(Matcher))) >>
-            separator: option!(syn!(Separator)) >>
-            repetition: syn!(Repetition) >>
-            (Matcher::Repeat { content: content.1, separator, repetition })
-        ) |
-        delimited!(many0!(syn!(Matcher))) => {
-            |(delimiter, content)| Matcher::Group { delimiter, content }
-        } |
-        do_parse!(
-            not!(syn!(Dollar)) >>
-            punct: syn!(Punct) >>
-            (Matcher::Punct(punct))
-        ) |
-        call!(Ident::parse_any) => { Matcher::Ident } |
-        syn!(Literal) => { Matcher::Literal }
-    ));
+fn parse_fragment_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
+    input.parse::<syn::token::Dollar>()?;
+    let name = input.call(Ident::parse_any)?;
+    input.parse::<syn::token::Colon>()?;
+    let fragment = input.parse()?;
+
+    Ok(Matcher::Fragment { name, fragment })
 }
 
-impl Synom for Repetition {
-    named!(parse -> Self, alt!(
-        punct!(*) => { |_| Repetition::Repeated } |
-        punct!(+) => { |_| Repetition::AtLeastOnce } |
-        punct!(?) => { |_| Repetition::AtMostOnce }
-    ));
+fn parse_repeat_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
+    input.parse::<syn::token::Dollar>()?;
+    let content;
+    parenthesized!(content in input);
+    let separator = input.parse().ok();
+    let repetition = input.parse()?;
+
+    Ok(Matcher::Repeat {
+        content: {
+            let mut v = Vec::new();
+            while let Ok(matcher) = content.parse() {
+                v.push(matcher);
+            }
+            v
+        },
+        separator,
+        repetition
+    })
 }
 
-impl Synom for Separator {
-    named!(parse -> Self, alt!(
-        do_parse!(
-            not!(syn!(Repetition)) >>
-            punct: syn!(Punct) >>
-            (Separator::Punct(punct))
-        ) |
-        call!(Ident::parse_any) => { Separator::Ident } |
-        syn!(Literal) => { Separator::Literal }
-    ));
+fn parse_group_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
+    let content;
+    let delimiter = delimited!(content in input);
+    Ok(Matcher::Group {
+        delimiter,
+        content: {
+            let mut v = Vec::new();
+            while let Ok(matcher) = content.parse() {
+                v.push(matcher);
+            }
+            v
+        }
+    })
 }
 
-impl Synom for Fragment {
-    named!(parse -> Self, alt!(
-        custom_keyword!(ident) => { |_| Fragment::Ident } |
-        custom_keyword!(path) => { |_| Fragment::Path } |
-        custom_keyword!(expr) => { |_| Fragment::Expr } |
-        custom_keyword!(ty) => { |_| Fragment::Ty } |
-        custom_keyword!(pat) => { |_| Fragment::Pat } |
-        custom_keyword!(stmt) => { |_| Fragment::Stmt } |
-        custom_keyword!(block) => { |_| Fragment::Block } |
-        custom_keyword!(item) => { |_| Fragment::Item } |
-        custom_keyword!(meta) => { |_| Fragment::Meta } |
-        custom_keyword!(tt) => { |_| Fragment::Tt } |
-        custom_keyword!(vis) => { |_| Fragment::Vis } |
-        custom_keyword!(literal) => { |_| Fragment::Literal } |
-        custom_keyword!(lifetime) => { |_| Fragment::Lifetime }
-    ));
+fn parse_punct_matcher(input: ParseStream) -> syn::parse::Result<Matcher> {
+    if input.parse::<syn::token::Dollar>().is_ok() {
+        return Err(input.error(""));
+    }
+
+    input.parse().map(Matcher::Punct)
 }
 
-pub fn parse(src: &str) -> Result<MacroRules, syn::synom::ParseError> {
+impl Parse for Matcher {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        if let Ok(fragment) = input.call(parse_fragment_matcher) {
+            Ok(fragment)
+        } else if let Ok(repetition) = input.call(parse_repeat_matcher) {
+            Ok(repetition)
+        } else if let Ok(group) = input.call(parse_group_matcher) {
+            Ok(group)
+        } else if let Ok(punct) = input.call(parse_punct_matcher) {
+            Ok(punct)
+        } else if let Ok(ident) = input.call(Ident::parse_any) {
+            Ok(Matcher::Ident(ident))
+        } else if let Ok(syn::Lifetime { ident, .. }) = input.parse() {
+            Ok(Matcher::Ident(ident))
+        } else if let Ok(literal) = input.parse::<Literal>() {
+            Ok(Matcher::Literal(literal))
+        } else {
+            Err(input.error("expected matcher"))
+        }
+    }
+}
+
+impl Parse for Repetition {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        if input.parse::<syn::token::Star>().is_ok() {
+            Ok(Repetition::Repeated)
+        } else if input.parse::<syn::token::Add>().is_ok() {
+            Ok(Repetition::AtLeastOnce)
+        } else if input.parse::<syn::token::Question>().is_ok() {
+            Ok(Repetition::AtMostOnce)
+        } else {
+            Err(input.error("expected repetition marker"))
+        }
+    }
+}
+
+impl Parse for Separator {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        if let Ok(punct) = input.call(|content| {
+            if content.parse::<Repetition>().is_ok() {
+                return Err(content.error(""));
+            }
+            content.parse::<Punct>()
+        }) {
+            Ok(Separator::Punct(punct))
+        } else if let Ok(ident) = input.call(Ident::parse_any) {
+            Ok(Separator::Ident(ident))
+        } else if let Ok(lit) = input.parse::<Literal>() {
+            Ok(Separator::Literal(lit))
+        } else {
+            Err(input.error("expected separator"))
+        }
+    }
+}
+
+impl Parse for Fragment {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        if input.parse::<kw::ident>().is_ok() {
+            Ok(Fragment::Ident)
+        } else if input.parse::<kw::path>().is_ok() {
+            Ok(Fragment::Path)
+        } else if input.parse::<kw::expr>().is_ok() {
+            Ok(Fragment::Expr)
+        } else if input.parse::<kw::ty>().is_ok() {
+            Ok(Fragment::Ty)
+        } else if input.parse::<kw::pat>().is_ok() {
+            Ok(Fragment::Pat)
+        } else if input.parse::<kw::stmt>().is_ok() {
+            Ok(Fragment::Stmt)
+        } else if input.parse::<kw::block>().is_ok() {
+            Ok(Fragment::Block)
+        } else if input.parse::<kw::item>().is_ok() {
+            Ok(Fragment::Item)
+        } else if input.parse::<kw::meta>().is_ok() {
+            Ok(Fragment::Meta)
+        } else if input.parse::<kw::tt>().is_ok() {
+            Ok(Fragment::Tt)
+        } else if input.parse::<kw::vis>().is_ok() {
+            Ok(Fragment::Vis)
+        } else if input.parse::<kw::literal>().is_ok() {
+            Ok(Fragment::Literal)
+        } else if input.parse::<kw::lifetime>().is_ok() {
+            Ok(Fragment::Lifetime)
+        } else {
+            Err(input.error("expected fragment keyword"))
+        }
+    }
+}
+
+pub fn parse(src: &str) -> syn::parse::Result<MacroRules> {
     syn::parse_str::<MacroRules>(src)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,17 +77,17 @@ pub enum Fragment {
 
 macro_rules! delimited {
     ($content:ident in $cursor:expr) => {
-        if let syn::export::Ok(parens) = syn::group::parse_parens(&$cursor) {
-            $content = parens.content;
+        if $cursor.peek(token::Paren) {
+            parenthesized!($content in $cursor);
             Delimiter::Parenthesis
-        } else if let syn::export::Ok(braces) = syn::group::parse_braces(&$cursor) {
-            $content = braces.content;
+        } else if $cursor.peek(token::Brace) {
+            braced!($content in $cursor);
             Delimiter::Brace
-        } else if let syn::export::Ok(brackets) = syn::group::parse_brackets(&$cursor) {
-            $content = brackets.content;
+        } else if $cursor.peek(token::Bracket) {
+            bracketed!($content in $cursor);
             Delimiter::Bracket
         } else {
-            return syn::export::Err($cursor.error("expected delimiter"));
+            return Err($cursor.error("expected delimiter"));
         }
     };
 }


### PR DESCRIPTION
Saw the call for participation on TWIR for issue #17, so decided to give it a shot. Passes tests, but seems to be slower than the current syn 0.14-based parser.