### PR TITLE
Upgrade to Syn 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Lukas Lueg <lukas.lueg@gmail.com>"]
 
 [dependencies]
-syn = { version = "0.14", features = ["full", "extra-traits"] }
+syn = { version = "0.15", features = ["full", "extra-traits"] }
 railroad = { git = "https://github.com/lukaslueg/railroad" }
 proc-macro2 = { version = "0.4", default-features=false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro2 = { version = "0.4", default-features=false }
 [dev-dependencies]
 tempdir = "0.3"
 lazy_static = "1.1"
+quote = "0.6"
 
 [features]
 visual-debug = ["railroad/visual-debug"]

--- a/benches/quick_error.rs
+++ b/benches/quick_error.rs
@@ -1,0 +1,279 @@
+#![recursion_limit = "512"]
+#![feature(test)]
+
+#[macro_use]
+extern crate quote;
+
+extern crate macro_railroad;
+extern crate syn;
+extern crate test;
+
+use macro_railroad::parser::MacroRules;
+use test::Bencher;
+
+#[bench]
+fn bench(b: &mut Bencher) {
+    let quick_error = quote! {
+        macro_rules! quick_error {
+            (   $(#[$meta:meta])*
+                pub enum $name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (   $(#[$meta:meta])*
+                enum $name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (   $(#[$meta:meta])*
+                pub enum $name:ident wraps $enum_name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (   $(#[$meta:meta])*
+                pub enum $name:ident wraps pub $enum_name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (   $(#[$meta:meta])*
+                enum $name:ident wraps $enum_name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (   $(#[$meta:meta])*
+                enum $name:ident wraps pub $enum_name:ident { $($chunks:tt)* }
+            ) => { ... };
+            (
+                WRAPPER $internal:ident [ $($strdef:tt)* ] $strname:ident
+                $(#[$meta:meta])*
+            ) => { ... };
+            (SORT [enum $name:ident $( #[$meta:meta] )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [ ]
+                queue [ ]
+            ) => { ... };
+            (SORT [pub enum $name:ident $( #[$meta:meta] )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [ ]
+                queue [ ]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*]
+                queue [ #[$qmeta:meta] $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*]
+                queue [ $qitem:ident $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*
+                    => $bitem:ident: $bmode:tt [$( $bvar:ident: $btyp:ty ),*] ]
+                queue [ #[$qmeta:meta] $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )* => $bitem:ident: UNIT [ ] ]
+                queue [($( $qvar:ident: $qtyp:ty ),+) $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )* => $bitem:ident: UNIT [ ] ]
+                queue [{ $( $qvar:ident: $qtyp:ty ),+} $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )* => $bitem:ident: UNIT [ ] ]
+                queue [{$( $qvar:ident: $qtyp:ty ),+ ,} $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*
+                        => $bitem:ident: $bmode:tt [$( $bvar:ident: $btyp:ty ),*] ]
+                queue [ {$( $qfuncs:tt )*} $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*
+                        => $bitem:ident: $bmode:tt [$( $bvar:ident: $btyp:ty ),*] ]
+                queue [ $qitem:ident $( $tail:tt )*]
+            ) => { ... };
+            (SORT [$( $def:tt )*]
+                items [$($( #[$imeta:meta] )*
+                        => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
+                                        {$( $ifuncs:tt )*} )* ]
+                buf [$( #[$bmeta:meta] )*
+                    => $bitem:ident: $bmode:tt [$( $bvar:ident: $btyp:ty ),*] ]
+                queue [ ]
+            ) => { ... };
+            (ENUM_DEFINITION [pub enum $name:ident $( #[$meta:meta] )*]
+                body [$($( #[$imeta:meta] )*
+                    => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
+                queue [ ]
+            ) => { ... };
+            (ENUM_DEFINITION [enum $name:ident $( #[$meta:meta] )*]
+                body [$($( #[$imeta:meta] )*
+                    => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
+                queue [ ]
+            ) => { ... };
+            (ENUM_DEFINITION [$( $def:tt )*]
+                body [$($( #[$imeta:meta] )*
+                    => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
+                queue [$( #[$qmeta:meta] )*
+                    => $qitem:ident: UNIT [ ] $( $queue:tt )*]
+            ) => { ... };
+            (ENUM_DEFINITION [$( $def:tt )*]
+                body [$($( #[$imeta:meta] )*
+                    => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
+                queue [$( #[$qmeta:meta] )*
+                    => $qitem:ident: TUPLE [$( $qvar:ident: $qtyp:ty ),+] $( $queue:tt )*]
+            ) => { ... };
+            (ENUM_DEFINITION [$( $def:tt )*]
+                body [$($( #[$imeta:meta] )*
+                    => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
+                queue [$( #[$qmeta:meta] )*
+                    => $qitem:ident: STRUCT [$( $qvar:ident: $qtyp:ty ),*] $( $queue:tt )*]
+            ) => { ... };
+            (IMPLEMENTATIONS
+                $name:ident {$(
+                    $item:ident: $imode:tt [$(#[$imeta:meta])*] [$( $var:ident: $typ:ty ),*] {$( $funcs:tt )*}
+                )*}
+            ) => { ... };
+            (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
+                { display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
+                { display($pattern:expr) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
+                { display($pattern:expr, $( $exprs:tt )*) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
+                { $t:tt $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
+                { }
+            ) => { ... };
+            (FIND_DESCRIPTION_IMPL $item:ident: $imode:tt $me:ident $fmt:ident
+                [$( $var:ident ),*]
+                { description($expr:expr) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DESCRIPTION_IMPL $item:ident: $imode:tt $me:ident $fmt:ident
+                [$( $var:ident ),*]
+                { $t:tt $( $tail:tt )*}
+            ) => { ... };
+            (FIND_DESCRIPTION_IMPL $item:ident: $imode:tt $me:ident $fmt:ident
+                [$( $var:ident ),*]
+                { }
+            ) => { ... };
+            (FIND_CAUSE_IMPL $item:ident: $imode:tt
+                [$( $var:ident ),*]
+                { cause($expr:expr) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_CAUSE_IMPL $item:ident: $imode:tt
+                [$( $var:ident ),*]
+                { $t:tt $( $tail:tt )*}
+            ) => { ... };
+            (FIND_CAUSE_IMPL $item:ident: $imode:tt
+                [$( $var:ident ),*]
+                { }
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: $imode:tt
+                [$( $var:ident: $typ:ty ),*]
+                { from() $( $tail:tt )*}
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: UNIT
+                [ ]
+                { from($ftyp:ty) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: TUPLE
+                [$( $var:ident: $typ:ty ),*]
+                { from($fvar:ident: $ftyp:ty) -> ($( $texpr:expr ),*) $( $tail:tt )*}
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: STRUCT
+                [$( $var:ident: $typ:ty ),*]
+                { from($fvar:ident: $ftyp:ty) -> {$( $tvar:ident: $texpr:expr ),*} $( $tail:tt )*}
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: $imode:tt
+                [$( $var:ident: $typ:ty ),*]
+                { $t:tt $( $tail:tt )*}
+            ) => { ... };
+            (FIND_FROM_IMPL $name:ident $item:ident: $imode:tt
+                [$( $var:ident: $typ:ty ),*]
+                { }
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: TUPLE
+                [$( $var:ident: $typ:ty ),*]
+                { context($cvar:ident: AsRef<$ctyp:ty>, $fvar:ident: $ftyp:ty)
+                    -> ($( $texpr:expr ),*) $( $tail:tt )* }
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: TUPLE
+                [$( $var:ident: $typ:ty ),*]
+                { context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
+                    -> ($( $texpr:expr ),*) $( $tail:tt )* }
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: STRUCT
+                [$( $var:ident: $typ:ty ),*]
+                { context($cvar:ident: AsRef<$ctyp:ty>, $fvar:ident: $ftyp:ty)
+                    -> {$( $tvar:ident: $texpr:expr ),*} $( $tail:tt )* }
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: STRUCT
+                [$( $var:ident: $typ:ty ),*]
+                { context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
+                    -> {$( $tvar:ident: $texpr:expr ),*} $( $tail:tt )* }
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: $imode:tt
+                [$( $var:ident: $typ:ty ),*]
+                { $t:tt $( $tail:tt )*}
+            ) => { ... };
+            (FIND_CONTEXT_IMPL $name:ident $item:ident: $imode:tt
+                [$( $var:ident: $typ:ty ),*]
+                { }
+            ) => { ... };
+            (ITEM_BODY $(#[$imeta:meta])* $item:ident: UNIT
+            ) => { ... };
+            (ITEM_BODY $(#[$imeta:meta])* $item:ident: TUPLE
+                [$( $typ:ty ),*]
+            ) => { ... };
+            (ITEM_BODY $(#[$imeta:meta])* $item:ident: STRUCT
+                [$( $var:ident: $typ:ty ),*]
+            ) => { ... };
+            (ITEM_PATTERN $name:ident $item:ident: UNIT []
+            ) => { ... };
+            (ITEM_PATTERN $name:ident $item:ident: TUPLE
+                [$( ref $var:ident ),*]
+            ) => { ... };
+            (ITEM_PATTERN $name:ident $item:ident: STRUCT
+                [$( ref $var:ident ),*]
+            ) => { ... };
+            (ERROR_CHECK $imode:tt display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK $imode:tt display($pattern: expr) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK $imode:tt display($pattern: expr, $( $exprs:tt )*) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK $imode:tt description($expr:expr) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK $imode:tt cause($expr:expr) $($tail:tt)*) => { ... };
+            (ERROR_CHECK $imode:tt from() $($tail:tt)*) => { ... };
+            (ERROR_CHECK $imode:tt from($ftyp:ty) $($tail:tt)*) => { ... };
+            (ERROR_CHECK TUPLE from($fvar:ident: $ftyp:ty) -> ($( $e:expr ),*) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK STRUCT from($fvar:ident: $ftyp:ty) -> {$( $v:ident: $e:expr ),*} $( $tail:tt )*) => { ... };
+            (ERROR_CHECK TUPLE context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
+                -> ($( $e:expr ),*) $( $tail:tt )*) => { ... };
+            (ERROR_CHECK STRUCT context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
+                -> {$( $v:ident: $e:expr ),*} $( $tail:tt )*) => { ... };
+            (ERROR_CHECK $imode:tt ) => { ... };
+            (IDENT $ident:ident) => { ... };
+        }
+    };
+    b.iter(|| syn::parse2::<MacroRules>(quick_error.clone()).unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,10 @@ pub mod parser;
 pub mod lowering;
 pub mod diagram;
 
+use syn::parse::Result;
+
 /// Create a syntax diagram as an SVG from the given macro_rules!-source.
-pub fn to_diagram(src: &str) -> Result<String, syn::synom::ParseError> {
+pub fn to_diagram(src: &str) -> Result<String> {
 
     // Parser-tree, basically as rustc sees it
     let macro_rules = parser::parse(&src)?;

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -130,6 +130,7 @@ impl From<parser::Matcher> for Matcher {
         match m {
             parser::Matcher::Punct(p) => Matcher::Literal(p.to_string()),
             parser::Matcher::Ident(i) => Matcher::Literal(i.to_string()),
+            parser::Matcher::Lifetime(l) => Matcher::Literal(l.to_string()),
             parser::Matcher::Literal(l) => Matcher::Literal(l.to_string()),
             parser::Matcher::Group { delimiter, content } => {
                 // We actually keep Groups as the parser sees them, representing them


### PR DESCRIPTION
Some ideas for how I would implement the Syn upgrade. I am going to be busy for the rest of the week so feel free to take any ideas from here and incorporate into #18 as makes sense.

#18 mentioned a performance degradation -- I added a benchmark and found that this PR improves parsing performance by about 20% compared to Syn 0.14. You can confirm by running `cargo bench` against the first commit which just adds the benchmark, and against the second commit which contains the 0.15 code.